### PR TITLE
bug-fix: Fix the multi-gpu container pull command 1_create_server

### DIFF
--- a/1_create_server.ipynb
+++ b/1_create_server.ipynb
@@ -321,7 +321,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "s.execute(\"pytorch/pytorch:2.5.1-cuda12.4-cudnn9-devel\")"
+    "s.execute(\"docker pull pytorch/pytorch:2.5.1-cuda12.4-cudnn9-devel\")"
    ]
   },
   {
@@ -341,22 +341,22 @@
    ]
   }
  ],
- "nbformat": 4,
- "nbformat_minor": 4,
  "metadata": {
   "kernelspec": {
-   "name": "python3",
    "display_name": "Python 3 (ipykernel)",
-   "language": "python"
+   "language": "python",
+   "name": "python3"
   },
   "language_info": {
-   "name": "python",
    "codemirror_mode": {
     "name": "ipython",
     "version": "3"
    },
    "file_extension": ".py",
-   "mimetype": "text/x-python"
+   "mimetype": "text/x-python",
+   "name": "python"
   }
- }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
 }

--- a/snippets/create_server.md
+++ b/snippets/create_server.md
@@ -273,7 +273,7 @@ You will continue working from the next notebook! But, if you are planning to do
 
 ::: {.cell .code}
 ```python
-s.execute("pytorch/pytorch:2.5.1-cuda12.4-cudnn9-devel")
+s.execute("docker pull pytorch/pytorch:2.5.1-cuda12.4-cudnn9-devel")
 ```
 :::
 


### PR DESCRIPTION
Fixed the issue with pulling multi-gpu image in
- 1_create_server.ipynb notebook
- snippets/create_server.md

The command lacked the "docker pull" keyword and only had reference to the image